### PR TITLE
Relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,16 @@ system GizmoMaker {
         
         structure {
             string Name,
-            int ItemCount,
-            Whozit[] Whozits,
-            Thingamajig[] Thingamajigs,
-            Dohickey Dohickey
+            int ItemCount
+        },
+        
+        relationships {
+            # one to many
+            -> Whozit,
+            -> Thingamajig,
+            
+            # one to one
+            -| Dohicky
         },
         
         behaviors {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ system GizmoMaker {
     aggregate Whatzit {
         description "The best selling thing ever!",
         
-        properties {
+        structure {
             string Name,
             int ItemCount,
             Whozit[] Whozits,
@@ -45,7 +45,7 @@ system GizmoMaker {
         
         # dto is an alias to 'projection'.  They will do the same thing.
         dto WhatzitDto2 {
-            properties {
+            structure {
                 string Name
             }
         },
@@ -53,7 +53,7 @@ system GizmoMaker {
         entity Whozit {
             description "It has a face!",
             
-            properties {
+            structure {
                 string Name,
                 string ModeledAfter
             },

--- a/src/DBot.Tests/SampleData/Valid/ComplexSystem.txt
+++ b/src/DBot.Tests/SampleData/Valid/ComplexSystem.txt
@@ -4,7 +4,7 @@ system GizmoMaker {
     aggregate Whatzit {
         description "The best selling thing ever!",
         
-        properties {
+        structure {
             string Name,
             int ItemCount,
             Whozit[] Whozits,
@@ -23,14 +23,14 @@ system GizmoMaker {
         },
         
         projection WhatzitDto {
-            properties {
+            structure {
                 string Name,
                 int ItemCount
             }
         },
         
         dto WhatzitDto2 {
-            properties {
+            structure {
                 string Name,
                 int ItemCount
             }
@@ -39,7 +39,7 @@ system GizmoMaker {
         entity Whozit {
             description "It has a face!",
             
-            properties {
+            structure {
                 string Name,
                 string ModeledAfter
             },

--- a/src/DBot.Tests/SampleData/Valid/ComplexSystem.txt
+++ b/src/DBot.Tests/SampleData/Valid/ComplexSystem.txt
@@ -6,10 +6,13 @@ system GizmoMaker {
         
         structure {
             string Name,
-            int ItemCount,
-            Whozit[] Whozits,
-            Thingamajig[] Thingamajigs,
-            Dohickey Dohickey
+            int ItemCount
+        },
+        
+        relationships {
+            -> Whozit,
+            -> Thingamajig,
+            -| Dohicky
         },
         
         behaviors {

--- a/src/DBot/Commands.cs
+++ b/src/DBot/Commands.cs
@@ -1,4 +1,5 @@
 ﻿using DBot.Commands;
+using DBot.Commands.Diagrams;
 using Spectre.Console.Cli;
 
 namespace DBot;
@@ -14,6 +15,11 @@ public static class AppCommands
         config.AddBranch("analyze", analyze =>
         {
             analyze.AddCommand<Complexity>("complexity");
+        });
+        
+        config.AddBranch("diagram", diagram =>
+        {
+            diagram.AddCommand<EntityRelationshipDiagram>("er");
         });
         
     }

--- a/src/DBot/Commands/Common/DslCommand.cs
+++ b/src/DBot/Commands/Common/DslCommand.cs
@@ -7,7 +7,7 @@ using Superpower.Model;
 
 #pragma warning disable CS8765
 
-namespace DBot.Commands;
+namespace DBot.Commands.Common;
 
 public abstract class DslCommand<TSettings> : Command<TSettings>
     where TSettings : SourceFileSettings

--- a/src/DBot/Commands/Common/ExitCodes.cs
+++ b/src/DBot/Commands/Common/ExitCodes.cs
@@ -1,4 +1,4 @@
-﻿namespace DBot.Commands;
+﻿namespace DBot.Commands.Common;
 
 public enum ExitCodes
 {

--- a/src/DBot/Commands/Common/SourceFileSettings.cs
+++ b/src/DBot/Commands/Common/SourceFileSettings.cs
@@ -1,7 +1,7 @@
 ﻿using Spectre.Console;
 using Spectre.Console.Cli;
 
-namespace DBot.Commands;
+namespace DBot.Commands.Common;
 
 public class SourceFileSettings : CommandSettings
 {

--- a/src/DBot/Commands/Complexity.cs
+++ b/src/DBot/Commands/Complexity.cs
@@ -1,4 +1,5 @@
 ﻿using DBot.Analyzers;
+using DBot.Commands.Common;
 using DBot.Domain;
 using Spectre.Console;
 using Spectre.Console.Cli;

--- a/src/DBot/Commands/Diagrams/DiagramSettings.cs
+++ b/src/DBot/Commands/Diagrams/DiagramSettings.cs
@@ -1,0 +1,14 @@
+﻿using DBot.Commands.Common;
+using Spectre.Console.Cli;
+
+namespace DBot.Commands.Diagrams;
+
+public class DiagramSettings : SourceFileSettings
+{
+    [CommandOption("-f|--format")] public DiagramFormat DiagramFormat { get; set; } = DiagramFormat.Mermaid;
+}
+
+public enum DiagramFormat
+{
+    Mermaid
+}

--- a/src/DBot/Commands/Diagrams/EntityRelationshipDiagram.cs
+++ b/src/DBot/Commands/Diagrams/EntityRelationshipDiagram.cs
@@ -1,0 +1,10 @@
+﻿using DBot.Commands.Common;
+using DBot.Domain;
+using Spectre.Console;
+
+namespace DBot.Commands.Diagrams;
+
+public class EntityRelationshipDiagram : DslCommand<DiagramSettings>
+{
+    protected override void Process(CodeElement system) => AnsiConsole.WriteLine("ER Diagrams will go here.");
+}

--- a/src/DBot/Commands/Parse.cs
+++ b/src/DBot/Commands/Parse.cs
@@ -1,4 +1,5 @@
-﻿using DBot.Domain;
+﻿using DBot.Commands.Common;
+using DBot.Domain;
 using Spectre.Console;
 
 namespace DBot.Commands;

--- a/src/DBot/DBot.csproj
+++ b/src/DBot/DBot.csproj
@@ -11,6 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Scriban" Version="5.0.0" />
       <PackageReference Include="Spectre.Console" Version="0.43.0" />
       <PackageReference Include="Superpower" Version="3.0.0" />
     </ItemGroup>
@@ -20,6 +21,10 @@
       <Content Include="Sample.txt">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Commands\Diagrams\Generators" />
     </ItemGroup>
 
 </Project>

--- a/src/DBot/Domain/Relationship.cs
+++ b/src/DBot/Domain/Relationship.cs
@@ -1,0 +1,38 @@
+﻿using System.Diagnostics;
+
+namespace DBot.Domain;
+
+[DebuggerDisplay("Relationship to {Name}")]
+public class Relationship : CodeElement
+{
+    public Relationship(RelationshipType type, string name)
+    {
+        Type = type;
+        Name = name;
+    }
+
+    public RelationshipType Type { get; }
+    public string Name { get; }
+    
+    public enum RelationshipType
+    {
+        ManyToMany,
+        OneToMany,
+    }
+}
+
+[DebuggerDisplay("relationships")]
+public class RelationshipListing : BaseHierarchicalCodeElement
+{
+    public RelationshipListing() : base("relationships")
+    {
+    }
+
+    public RelationshipListing(IEnumerable<CodeElement> elements) : this()
+    {
+        foreach (var element in elements)
+        {
+            AddChild(element);
+        }
+    }
+}

--- a/src/DBot/Dsl/Evaluation/ExpressionEvaluator.cs
+++ b/src/DBot/Dsl/Evaluation/ExpressionEvaluator.cs
@@ -47,6 +47,7 @@ public static class ExpressionEvaluator
             Keyword.Events => new EventListing(v.Children.Select(x => new Event(x.ToString()!))),
             Keyword.Description => new Description(v.Children.First().ToString()!),
             Keyword.Structure => new PropertyListing(v.Children.Select(x => new Property(x.ToString()!))),
+            Keyword.Relationships => new RelationshipListing(v.Children.Cast<RelationshipValue>().Select(x => new Relationship(x.Type, x.Target.ToString()!))),
             _ => throw new ArgumentOutOfRangeException()
         },
         TripletValue v => v.Keyword.Value switch {

--- a/src/DBot/Dsl/Evaluation/ExpressionEvaluator.cs
+++ b/src/DBot/Dsl/Evaluation/ExpressionEvaluator.cs
@@ -46,7 +46,7 @@ public static class ExpressionEvaluator
             Keyword.Behaviors => new BehaviorListing(v.Children.Cast<RaisesValue>().Select(x => new Behavior(x.BehaviorName.ToString()!, x.EventName.ToString()!))),
             Keyword.Events => new EventListing(v.Children.Select(x => new Event(x.ToString()!))),
             Keyword.Description => new Description(v.Children.First().ToString()!),
-            Keyword.Properties => new PropertyListing(v.Children.Select(x => new Property(x.ToString()!))),
+            Keyword.Structure => new PropertyListing(v.Children.Select(x => new Property(x.ToString()!))),
             _ => throw new ArgumentOutOfRangeException()
         },
         TripletValue v => v.Keyword.Value switch {

--- a/src/DBot/Dsl/Expressions/RelationshipValue.cs
+++ b/src/DBot/Dsl/Expressions/RelationshipValue.cs
@@ -1,0 +1,23 @@
+﻿using DBot.Domain;
+using DBot.Dsl.Parsing;
+
+namespace DBot.Dsl.Expressions;
+
+public class RelationshipValue : Expression
+{
+    public RelationshipValue(ExpressionToken token, Expression relationshipTarget)
+    {
+        Type = Convert(token);
+        Target = relationshipTarget;
+    }
+    
+    public Relationship.RelationshipType Type { get; }
+    public Expression Target { get; }
+
+    private static Relationship.RelationshipType Convert(ExpressionToken token) => token switch
+    {
+        ExpressionToken.OneToManyRelationship => Relationship.RelationshipType.OneToMany,
+        ExpressionToken.OneToOneRelationship => Relationship.RelationshipType.ManyToMany,
+        _ => throw new ArgumentOutOfRangeException(nameof(token), token, null)
+    };
+}

--- a/src/DBot/Dsl/Parsing/ExpressionParser.cs
+++ b/src/DBot/Dsl/Parsing/ExpressionParser.cs
@@ -40,6 +40,7 @@ public static class ExpressionParser
             .Or(PropertiesParsers.Properties)
             .Or(BehaviorsParsers.Behaviors)
             .Or(ServicesParsers.Services)
+            .Or(RelationshipParsers.Relationships)
             .Or(CodeElementKeyword)
             .Or(UniversalParsers.String);
     

--- a/src/DBot/Dsl/Parsing/ExpressionToken.cs
+++ b/src/DBot/Dsl/Parsing/ExpressionToken.cs
@@ -14,6 +14,8 @@ public enum ExpressionToken
     [Token(Category = "keyword")] Entity,
     [Token(Category = "keyword")] Events,
     [Token(Category = "keyword")] None,
+    [Token(Example = "->")] OneToManyRelationship,
+    [Token(Example = "-|")] OneToOneRelationship,
     [Token(Category = "keyword")] Projection,
     [Token(Category = "keyword")] Structure,
     [Token(Category = "keyword")] Raises,

--- a/src/DBot/Dsl/Parsing/ExpressionToken.cs
+++ b/src/DBot/Dsl/Parsing/ExpressionToken.cs
@@ -17,6 +17,7 @@ public enum ExpressionToken
     [Token(Category = "keyword")] Projection,
     [Token(Category = "keyword")] Structure,
     [Token(Category = "keyword")] Raises,
+    [Token(Category = "keyword")] Relationships,
     [Token(Category = "keyword")] Returns,
     [Token(Category = "keyword")] Service,
     [Token(Category = "keyword")] ValueObject,

--- a/src/DBot/Dsl/Parsing/ExpressionToken.cs
+++ b/src/DBot/Dsl/Parsing/ExpressionToken.cs
@@ -15,7 +15,7 @@ public enum ExpressionToken
     [Token(Category = "keyword")] Events,
     [Token(Category = "keyword")] None,
     [Token(Category = "keyword")] Projection,
-    [Token(Category = "keyword")] Properties,
+    [Token(Category = "keyword")] Structure,
     [Token(Category = "keyword")] Raises,
     [Token(Category = "keyword")] Returns,
     [Token(Category = "keyword")] Service,

--- a/src/DBot/Dsl/Parsing/ExpressionTokenizer.cs
+++ b/src/DBot/Dsl/Parsing/ExpressionTokenizer.cs
@@ -26,6 +26,8 @@ public static class ExpressionTokenizer
         .Match(Character.EqualTo(','), ExpressionToken.Comma)
         .Match(Span.EqualTo("dto"), ExpressionToken.Projection)
         .Match(Span.EqualTo("=>"), ExpressionToken.Returns)
+        .Match(Span.EqualTo("->"), ExpressionToken.OneToManyRelationship)
+        .Match(Span.EqualTo("-|"), ExpressionToken.OneToOneRelationship)
         // .Match(Character.EqualTo('\n'), ExpressionToken.NewLine)
         // .Match(Span.EqualTo("\r\n"), ExpressionToken.NewLine)
         .MatchKeywords()

--- a/src/DBot/Dsl/Parsing/Keyword.cs
+++ b/src/DBot/Dsl/Parsing/Keyword.cs
@@ -15,6 +15,7 @@ public enum Keyword
     Projection,
     Structure,
     Raises,
+    Relationships,
     Returns,
     Service,
     System,
@@ -32,6 +33,7 @@ public static class ExpressionTextParsers
             .Or(Span.EqualTo("none").Value(Parsing.Keyword.None))
             .Or(Span.EqualTo("projection").Value(Parsing.Keyword.Projection))
             .Or(Span.EqualTo("raises").Value(Parsing.Keyword.Raises))
+            .Try().Or(Span.EqualTo("relationships").Value(Parsing.Keyword.Relationships))
             .Try().Or(Span.EqualTo("returns").Value(Parsing.Keyword.Returns))
             .Or(Span.EqualTo("service").Value(Parsing.Keyword.Service))
             .Try().Or(Span.EqualTo("structure").Value(Parsing.Keyword.Structure))
@@ -50,6 +52,7 @@ public static class ExpressionTextParsers
             .Match(Span.EqualTo("none"), ExpressionToken.None)
             .Match(Span.EqualTo("projection"), ExpressionToken.Projection)
             .Match(Span.EqualTo("raises"), ExpressionToken.Raises)
+            .Match(Span.EqualTo("relationships"), ExpressionToken.Relationships)
             .Match(Span.EqualTo("returns"), ExpressionToken.Returns)
             .Match(Span.EqualTo("service"), ExpressionToken.Service)
             .Match(Span.EqualTo("structure"), ExpressionToken.Structure)

--- a/src/DBot/Dsl/Parsing/Keyword.cs
+++ b/src/DBot/Dsl/Parsing/Keyword.cs
@@ -13,7 +13,7 @@ public enum Keyword
     Events,
     None,
     Projection,
-    Properties,
+    Structure,
     Raises,
     Returns,
     Service,
@@ -31,10 +31,10 @@ public static class ExpressionTextParsers
             .Try().Or(Span.EqualTo("events").Value(Parsing.Keyword.Events))
             .Or(Span.EqualTo("none").Value(Parsing.Keyword.None))
             .Or(Span.EqualTo("projection").Value(Parsing.Keyword.Projection))
-            .Try().Or(Span.EqualTo("properties").Value(Parsing.Keyword.Properties))
             .Or(Span.EqualTo("raises").Value(Parsing.Keyword.Raises))
             .Try().Or(Span.EqualTo("returns").Value(Parsing.Keyword.Returns))
             .Or(Span.EqualTo("service").Value(Parsing.Keyword.Service))
+            .Try().Or(Span.EqualTo("structure").Value(Parsing.Keyword.Structure))
             .Try().Or(Span.EqualTo("system").Value(Parsing.Keyword.System))
             .Or(Span.EqualTo("value").Value(Parsing.Keyword.ValueObject));
 
@@ -49,9 +49,9 @@ public static class ExpressionTextParsers
             .Match(Span.EqualTo("events"), ExpressionToken.Events)
             .Match(Span.EqualTo("none"), ExpressionToken.None)
             .Match(Span.EqualTo("projection"), ExpressionToken.Projection)
-            .Match(Span.EqualTo("properties"), ExpressionToken.Properties)
             .Match(Span.EqualTo("raises"), ExpressionToken.Raises)
             .Match(Span.EqualTo("returns"), ExpressionToken.Returns)
             .Match(Span.EqualTo("service"), ExpressionToken.Service)
+            .Match(Span.EqualTo("structure"), ExpressionToken.Structure)
             .Match(Span.EqualTo("value"), ExpressionToken.ValueObject);
 }

--- a/src/DBot/Dsl/Parsing/Parsers/PropertiesParsers.cs
+++ b/src/DBot/Dsl/Parsing/Parsers/PropertiesParsers.cs
@@ -21,7 +21,7 @@ public class PropertiesParsers
         select (Expression) new ChildNodes(values);
     
     public static ExpressionTokenParser Properties { get; } =
-        from keyword in Token.EqualTo(ExpressionToken.Properties)
+        from keyword in Token.EqualTo(ExpressionToken.Structure)
         from array in PropertiesArray
-        select (Expression) new CoupletValue(new KeywordValue(Keyword.Properties), ((ChildNodes) array).Children);
+        select (Expression) new CoupletValue(new KeywordValue(Keyword.Structure), ((ChildNodes) array).Children);
 }

--- a/src/DBot/Dsl/Parsing/Parsers/RelationshipParsers.cs
+++ b/src/DBot/Dsl/Parsing/Parsers/RelationshipParsers.cs
@@ -1,0 +1,29 @@
+﻿using DBot.Dsl.Expressions;
+using Superpower;
+using Superpower.Parsers;
+
+namespace DBot.Dsl.Parsing.Parsers;
+
+using ExpressionTokenParser = TokenListParser<ExpressionToken, Expression>;
+
+public static class RelationshipParsers
+{
+    private static ExpressionTokenParser Relationship { get; } =
+        from type in 
+            Token.EqualTo(ExpressionToken.OneToManyRelationship)
+                .Or(Token.EqualTo(ExpressionToken.OneToOneRelationship))
+        from value in UniversalParsers.String
+        select (Expression) new RelationshipValue(type.Kind, value);
+
+    private static ExpressionTokenParser RelationshipArray { get; } =
+        from begin in Token.EqualTo(ExpressionToken.LBracket)
+        from values in Parse.Ref(() => Relationship)
+            .ManyDelimitedBy(Token.EqualTo(ExpressionToken.Comma),
+                Token.EqualTo(ExpressionToken.RBracket))
+        select (Expression) new ChildNodes(values);
+
+    public static ExpressionTokenParser Relationships { get; } =
+        from keyword in Token.EqualTo(ExpressionToken.Relationships)
+        from value in RelationshipArray
+        select (Expression) new CoupletValue(new KeywordValue(Keyword.Relationships), ((ChildNodes) value).Children);
+}

--- a/src/DBot/Dsl/Parsing/Parsers/UniversalParsers.cs
+++ b/src/DBot/Dsl/Parsing/Parsers/UniversalParsers.cs
@@ -15,7 +15,7 @@ public static class UniversalParsers
             .Or(Token.EqualTo(ExpressionToken.Events))
             .Or(Token.EqualTo(ExpressionToken.None))
             .Or(Token.EqualTo(ExpressionToken.Projection))
-            .Or(Token.EqualTo(ExpressionToken.Properties))
+            .Or(Token.EqualTo(ExpressionToken.Structure))
             .Or(Token.EqualTo(ExpressionToken.Raises))
             .Or(Token.EqualTo(ExpressionToken.Service))
             .Or(Token.EqualTo(ExpressionToken.System))

--- a/src/DBot/Dsl/Parsing/Parsers/UniversalParsers.cs
+++ b/src/DBot/Dsl/Parsing/Parsers/UniversalParsers.cs
@@ -17,6 +17,7 @@ public static class UniversalParsers
             .Or(Token.EqualTo(ExpressionToken.Projection))
             .Or(Token.EqualTo(ExpressionToken.Structure))
             .Or(Token.EqualTo(ExpressionToken.Raises))
+            .Or(Token.EqualTo(ExpressionToken.Relationships))
             .Or(Token.EqualTo(ExpressionToken.Service))
             .Or(Token.EqualTo(ExpressionToken.System))
             .Or(Token.EqualTo(ExpressionToken.ValueObject))

--- a/src/DBot/Sample.txt
+++ b/src/DBot/Sample.txt
@@ -16,8 +16,11 @@ system "Contoso University" {
             Instructor Administrator,
             string Name,
             MoneyValue Budget,
-            DateTime StartDate,
-            Course[] Courses
+            DateTime StartDate
+        },
+        
+        relationships {
+            -> Course
         },
 
         events {
@@ -44,9 +47,12 @@ system "Contoso University" {
             structure {
                 Guid Id,
                 string Title,
-                string Credits,
-                EnrollmentDto Enrollments,
-                AssignmentDto Assignments
+                string Credits
+            },
+            
+            relationships {
+                -| EnrollmentDto,
+                -| AssignmentDto
             },
 
             # Renamed from his overload of domain names in the DTO layer
@@ -73,9 +79,11 @@ system "Contoso University" {
                 string Name,
                 string Currency,
                 decimal Budget,
-                DateTime StartDate,
-
-                CourseDto[] Courses
+                DateTime StartDate
+            },
+            
+            relationships {
+                -> CourseDto
             },
 
             # Renamed from his overload of domain names in the DTO layer
@@ -90,14 +98,7 @@ system "Contoso University" {
         entity Course {
             structure {
                 string Title,
-                int Credits,
-
-                # navigation property
-                Department Department,
-
-                # Do we really want this aggregate to reference entities in a different aggregate?
-                Enrollment[] StudentEnrollments,
-                Assignment[] InstructorAssignments
+                int Credits
             },
 
             events {
@@ -110,8 +111,11 @@ system "Contoso University" {
         structure {
             PersonName PersonName,
             DateTime HireDate,
-            OfficeLocation OfficeLocation,
-            Assignment[] Assignments
+            OfficeLocation OfficeLocation
+        },
+        
+        relationships {
+            -> Assignment
         },
 
         events {
@@ -153,9 +157,11 @@ system "Contoso University" {
                 Guid Id,
                 string FirstName,
                 string LastName,
-                DateTime HireDate,
-
-                InstructorCourseDto[] Courses
+                DateTime HireDate
+            },
+            
+            relationships {
+                -> InstructorCourseDto
             },
 
             # Renamed from his overload of domain names in the DTO layer
@@ -171,8 +177,11 @@ system "Contoso University" {
         structure {
             PersonName PersonName,
             DateTime EnrollmentDate,
-            DateTime CreateDate,
-            Enrollments[] Enrollments
+            DateTime CreateDate
+        },
+        
+        relationships {
+            -> Enrollment
         },
 
         events {
@@ -212,9 +221,11 @@ system "Contoso University" {
                 Guid Id,
                 string FirstName,
                 string LastName,
-                DateTime EnrollmentDate,
-
-                StudentEnrollmentDto[] Enrollments
+                DateTime EnrollmentDate
+            },
+            
+            relationships {
+                -> StudentEnrollmentDto
             },
 
             # Renamed from his overload of domain names in the DTO layer

--- a/src/DBot/Sample.txt
+++ b/src/DBot/Sample.txt
@@ -12,7 +12,7 @@ system "Contoso University" {
     description "A sample application that is just big enough to be realistic",
 
     aggregate Department {
-        properties {
+        structure {
             Instructor Administrator,
             string Name,
             MoneyValue Budget,
@@ -41,7 +41,7 @@ system "Contoso University" {
         },
 
         dto CourseDto {
-            properties {
+            structure {
                 Guid Id,
                 string Title,
                 string Credits,
@@ -51,7 +51,7 @@ system "Contoso University" {
 
             # Renamed from his overload of domain names in the DTO layer
             dto EnrollmentDto {
-                properties {
+                structure {
                     string FirstName,
                     string Lastname
                 }
@@ -59,7 +59,7 @@ system "Contoso University" {
 
             # Renamed from his overload of domain names in the DTO layer
             dto AssignmentDto {
-                properties {
+                structure {
                     string FirstName,
                     string Lastname
                 }
@@ -67,7 +67,7 @@ system "Contoso University" {
         },
 
         dto DepartmentDto {
-            properties {
+            structure {
                 Guid Id,
                 string Administrator,
                 string Name,
@@ -80,7 +80,7 @@ system "Contoso University" {
 
             # Renamed from his overload of domain names in the DTO layer
             dto CourseDto {
-                properties {
+                structure {
                     string Title,
                     int Credits
                 }
@@ -88,7 +88,7 @@ system "Contoso University" {
         },
 
         entity Course {
-            properties {
+            structure {
                 string Title,
                 int Credits,
 
@@ -107,7 +107,7 @@ system "Contoso University" {
     },
 
     aggregate Instructor {
-        properties {
+        structure {
             PersonName PersonName,
             DateTime HireDate,
             OfficeLocation OfficeLocation,
@@ -121,7 +121,7 @@ system "Contoso University" {
         },
 
         entity Assignment {
-            properties {
+            structure {
                 Instructor Instructor,
                 Course Course
             },
@@ -132,7 +132,7 @@ system "Contoso University" {
         },
 
         value OfficeLocation {
-            properties {
+            structure {
                 string Address,
                 string PostalCode,
                 string City
@@ -149,7 +149,7 @@ system "Contoso University" {
         },
 
         dto InstructorDto {
-            properties {
+            structure {
                 Guid Id,
                 string FirstName,
                 string LastName,
@@ -160,7 +160,7 @@ system "Contoso University" {
 
             # Renamed from his overload of domain names in the DTO layer
             dto InstructorCourseDto {
-                properties {
+                structure {
                     string Title
                 }
             }
@@ -168,7 +168,7 @@ system "Contoso University" {
     },
 
     aggregate Student {
-        properties {
+        structure {
             PersonName PersonName,
             DateTime EnrollmentDate,
             DateTime CreateDate,
@@ -182,7 +182,7 @@ system "Contoso University" {
         },
 
         entity Enrollment {
-            properties {
+            structure {
                 Course Course,
                 Student Student,
                 Grade Grade
@@ -190,7 +190,7 @@ system "Contoso University" {
         },
 
         value Grade {
-            properties {
+            structure {
                 Grade A,
                 Grade B,
                 Grade C,
@@ -208,7 +208,7 @@ system "Contoso University" {
         },
 
         dto StudentDto {
-            properties {
+            structure {
                 Guid Id,
                 string FirstName,
                 string LastName,
@@ -219,7 +219,7 @@ system "Contoso University" {
 
             # Renamed from his overload of domain names in the DTO layer
             dto StudentEnrollmentDto {
-                properties {
+                structure {
                     string Title,
                     string Grade
                 }
@@ -228,14 +228,14 @@ system "Contoso University" {
     },
 
     value MoneyValue { 
-        properties {
+        structure {
             decimal Value,
             string Currency,
             DateTime Moment
         }
     },
     value PersonName { 
-        properties {
+        structure {
             string First,
             string Last,
             string Full,


### PR DESCRIPTION
## Summary 
- Organizes the `commands` for simplicty in preparation for `diagram` support
- Renames the `property` keyword to `structure`
- Adds `relationship` keyword
- Adds `->` and `-|` operators to indicate one to many/one relationships

## Breaking changes

🛑 `property` keyword is no longer a thing.  Use `structure` instead`.  This 
